### PR TITLE
Load per-cat sprites and animations

### DIFF
--- a/src/prefabs/Cat.js
+++ b/src/prefabs/Cat.js
@@ -58,15 +58,14 @@ export default class Cat extends GameObjects.Container {
     }
     
     createSprite() {
-        // Get the sprite sheet key based on color
-        const spriteColor = this.scene.scene.get('PreloadScene').getClosestSpriteColor(this.data.color);
-        const spriteSheetKey = `cat_${spriteColor}`;
-        
+        // Use the preloaded sprite sheet for this cat
+        const spriteSheetKey = this.data.sprite.texture;
+
         console.log(`Cat ${this.data.name}: Creating sprite with texture ${spriteSheetKey}`);
-        
+
         // Main sprite using sprite sheet
         this.sprite = this.scene.add.sprite(0, 0, spriteSheetKey);
-        this.sprite.setScale(2); // Scale up 32x32 sprites to appear larger
+        this.sprite.setScale(1);
         this.add(this.sprite);
         
         // Name label


### PR DESCRIPTION
## Summary
- Preload each cat's 64x64 sprite sheet and generate idle/walk/sleep animations from `CAT_DATABASE`
- Use per-cat sprite texture when constructing `Cat` prefabs instead of color-based mapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fc3a657a883239a96356243432928