### PR TITLE
Load per-cat spritesheets

### DIFF
--- a/src/prefabs/Cat.js
+++ b/src/prefabs/Cat.js
@@ -58,15 +58,14 @@ export default class Cat extends GameObjects.Container {
     }
     
     createSprite() {
-        // Get the sprite sheet key based on color
-        const spriteColor = this.scene.scene.get('PreloadScene').getClosestSpriteColor(this.data.color);
-        const spriteSheetKey = `cat_${spriteColor}`;
-        
+        // Get the sprite sheet key based on cat id
+        const spriteSheetKey = `cat_${this.data.id}`;
+
         console.log(`Cat ${this.data.name}: Creating sprite with texture ${spriteSheetKey}`);
-        
+
         // Main sprite using sprite sheet
         this.sprite = this.scene.add.sprite(0, 0, spriteSheetKey);
-        this.sprite.setScale(2); // Scale up 32x32 sprites to appear larger
+        this.sprite.setScale(1); // Sprites are already 64x64
         this.add(this.sprite);
         
         // Name label

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -1,6 +1,6 @@
 import { Scene } from 'phaser';
 import { COLORS } from '../data/Constants';
-import { getAllCats } from '../data/CatDatabase';
+import { getAllCats, CAT_DATABASE } from '../data/CatDatabase';
 
 export default class PreloadScene extends Scene {
     constructor() {
@@ -58,9 +58,8 @@ export default class PreloadScene extends Scene {
         console.log('Loaded textures:', this.textures.list);
         
         // Check if cat sprites loaded
-        const catColors = ['orange', 'black', 'gray', 'brown', 'pink', 'blue', 'green', 'yellow'];
-        catColors.forEach(color => {
-            const key = `cat_idle_${color}`;
+        Object.keys(CAT_DATABASE).forEach(id => {
+            const key = `cat_${id}`;
             console.log(`Texture ${key} exists: ${this.textures.exists(key)}`);
         });
         
@@ -84,34 +83,16 @@ export default class PreloadScene extends Scene {
 
     loadRealAssets() { 
         console.log('LoadRealAssets: Starting to load cat sprite sheets');
-        
-        // Map of cat colors to sprite sheet files
-        const catSpriteSheets = {
-            'orange': 'orange_0.png',
-            'black': 'black_0.png',
-            'gray': 'grey_0.png',
-            'brown': 'brown_0.png',
-            'pink': 'pink_0.png',
-            'blue': 'blue_0.png',
-            'green': 'teal_0.png',  // Using teal as green
-            'yellow': 'yellow_0.png',
-            'white': 'white_0.png',
-            'calico': 'calico_0.png',
-            'red': 'red_0.png'
-        };
-        
-        // Load cat sprite sheets
-        Object.entries(catSpriteSheets).forEach(([color, filename]) => {
-            const key = `cat_${color}`;
-            const path = `cat_assets/${filename}`;
+
+        // Load cat sprite sheets based on database entries
+        Object.values(CAT_DATABASE).forEach(({ id }) => {
+            const key = `cat_${id}`;
+            const path = `assets/sprites/${key}.png`;
             console.log(`Loading sprite sheet: ${key} from ${path}`);
-            
-            // Each sprite sheet has 32x32 pixel sprites in a grid
+
             this.load.spritesheet(key, path, {
-                frameWidth: 32,
-                frameHeight: 32,
-                margin: 0,
-                spacing: 0
+                frameWidth: 64,
+                frameHeight: 64
             });
         });
         
@@ -127,44 +108,15 @@ export default class PreloadScene extends Scene {
         this.load.image('icon_heart', 'assets/sprites/icon_heart.png');
     }
 
-    // Map cat colors to available sprite colors
-    getClosestSpriteColor(hexColor) {
-        const colorMap = {
-            '#FF6B6B': 'pink',      // Whiskers - coral to pink
-            '#FF9F1C': 'orange',    // Simba - orange
-            '#9B59B6': 'pink',      // Luna - purple to pink
-            '#F39C12': 'orange',    // Tigger - golden to orange
-            '#7F8C8D': 'gray',      // Smokey - gray
-            '#E74C3C': 'orange',    // Patches - red to orange
-            '#2C3E50': 'gray',      // Shadow - dark gray
-            '#000000': 'black',     // Oreo - black
-            '#ECF0F1': 'gray',      // Mittens - white to gray
-            '#34495E': 'gray',      // Felix - charcoal to gray
-            '#8B4513': 'brown',     // Coco - brown
-            '#5D6D7E': 'gray',      // Pepper - blue-gray
-            '#D35400': 'orange',    // Boots - burnt orange
-            '#F8BBD0': 'pink',      // Bella - pink
-            '#FFAB00': 'orange',    // Milo - amber to orange
-            '#FDD835': 'yellow',    // Nala - yellow
-            '#43A047': 'green',     // Oliver - green
-            '#E91E63': 'pink',      // Roxy - hot pink
-            '#FF5722': 'orange',    // Chester - deep orange
-            '#FDD835': 'yellow'     // Tink - yellow
-        };
-        
-        return colorMap[hexColor] || 'gray';
-    }
-
     generateCatSprites() {
         console.log('Setting up cat sprites from loaded sprite sheets...');
         const cats = getAllCats();
-        
+
         cats.forEach(cat => {
-            const spriteColor = this.getClosestSpriteColor(cat.color);
-            const spriteSheetKey = `cat_${spriteColor}`;
-            
-            console.log(`Mapping ${cat.name} (${cat.color}) to sprite sheet: ${spriteSheetKey}`);
-            
+            const spriteSheetKey = `cat_${cat.id}`;
+
+            console.log(`Mapping ${cat.name} to sprite sheet: ${spriteSheetKey}`);
+
             // Update the cat's texture to use the sprite sheet
             cat.sprite.texture = spriteSheetKey;
             cat.spriteSheetKey = spriteSheetKey;
@@ -418,17 +370,15 @@ export default class PreloadScene extends Scene {
     
     createAnimations() {
         console.log('Creating animations for cat sprite sheets...');
-        
+
         // Create animations for each loaded sprite sheet
-        const catColors = ['orange', 'black', 'gray', 'brown', 'pink', 'blue', 'green', 'yellow', 'white', 'calico', 'red'];
-        
-        catColors.forEach(color => {
-            const spriteKey = `cat_${color}`;
-            
+        Object.keys(CAT_DATABASE).forEach(id => {
+            const spriteKey = `cat_${id}`;
+
             if (this.textures.exists(spriteKey)) {
                 // Based on the sprite sheet layout:
                 // Row 1 (frames 0-31): Sitting down
-                // Row 2 (frames 32-63): Looking around  
+                // Row 2 (frames 32-63): Looking around
                 // Row 3 (frames 64-95): Laying down
                 // Row 4 (frames 96-127): Walking
                 // Row 5 (frames 128-159): Running


### PR DESCRIPTION
## Summary
- Load each cat's spritesheet from `CAT_DATABASE` and drop color-based mapping.
- Assign cat textures by ID in both preload setup and Cat prefab.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fc3abbfe48323848c46b28ed90427