### PR TITLE
Use cat data texture for sprites

### DIFF
--- a/src/prefabs/Cat.js
+++ b/src/prefabs/Cat.js
@@ -58,12 +58,11 @@ export default class Cat extends GameObjects.Container {
     }
     
     createSprite() {
-        // Get the sprite sheet key based on color
-        const spriteColor = this.scene.scene.get('PreloadScene').getClosestSpriteColor(this.data.color);
-        const spriteSheetKey = `cat_${spriteColor}`;
-        
+        // Use the texture specified in the cat data
+        const spriteSheetKey = this.data.sprite.texture;
+
         console.log(`Cat ${this.data.name}: Creating sprite with texture ${spriteSheetKey}`);
-        
+
         // Main sprite using sprite sheet
         this.sprite = this.scene.add.sprite(0, 0, spriteSheetKey);
         this.sprite.setScale(2); // Scale up 32x32 sprites to appear larger

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -158,16 +158,19 @@ export default class PreloadScene extends Scene {
     generateCatSprites() {
         console.log('Setting up cat sprites from loaded sprite sheets...');
         const cats = getAllCats();
-        
+
         cats.forEach(cat => {
             const spriteColor = this.getClosestSpriteColor(cat.color);
             const spriteSheetKey = `cat_${spriteColor}`;
-            
-            console.log(`Mapping ${cat.name} (${cat.color}) to sprite sheet: ${spriteSheetKey}`);
-            
-            // Update the cat's texture to use the sprite sheet
-            cat.sprite.texture = spriteSheetKey;
-            cat.spriteSheetKey = spriteSheetKey;
+
+            // Only update the texture if it differs from the desired sprite sheet
+            if (cat.sprite.texture !== spriteSheetKey) {
+                console.log(`Updating ${cat.name} texture from ${cat.sprite.texture} to ${spriteSheetKey}`);
+                cat.sprite.texture = spriteSheetKey;
+            }
+
+            // Keep a reference to the sprite sheet key for animations
+            cat.spriteSheetKey = cat.sprite.texture;
         });
     }
 


### PR DESCRIPTION
## Summary
- Use `catData.sprite.texture` directly when creating cat sprites instead of recomputing color-based keys.
- Update `generateCatSprites` to change `catData.sprite.texture` only when the texture differs, keeping a reference for animations.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688fc3adda608323a0bf64f24dd9dd51