### PR TITLE
fix: correct idle animation frames to prevent sprite flicker

### DIFF
--- a/src/prefabs/Cat.js
+++ b/src/prefabs/Cat.js
@@ -126,7 +126,8 @@ export default class Cat extends GameObjects.Container {
         this.createStatusIndicators();
 
         // Set initial frame and start idle animation
-        this.sprite.setFrame(0);
+        // Idle animation begins at frame 16 of the sprite sheet
+        this.sprite.setFrame(16);
         this.playAnimation('idle');
 
         // Ensure sprite is visible
@@ -475,17 +476,17 @@ export default class Cat extends GameObjects.Container {
     getStaticFrame() {
         switch(this.currentState) {
             case CAT_STATES.IDLE:
-                return 0;
+                return 16; // Start of "looking around" row
             case CAT_STATES.WALKING:
-                return 2;
+                return 48; // First walking frame
             case CAT_STATES.SLEEPING:
-                return 6;
+                return 32; // First laying down frame
             case CAT_STATES.EATING:
-                return 1;
+                return 16;
             case CAT_STATES.PLAYING:
-                return 3;
+                return 48;
             default:
-                return 0;
+                return 16;
         }
     }
 

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -418,14 +418,14 @@ export default class PreloadScene extends Scene {
                 // Row 7 (frames 96-111): Side walk
                 // Row 8 (frames 112-127): Sitting 2.0
                 
-                // Idle/Sitting animation - use first few frames of sitting
+                // Idle animation - use "looking around" row for a gentle loop
                 this.anims.create({
                     key: `${spriteKey}_idle`,
                     frames: this.anims.generateFrameNumbers(spriteKey, {
-                        start: 0,
-                        end: 3
+                        start: 16,
+                        end: 23
                     }),
-                    frameRate: 4,
+                    frameRate: 6,
                     repeat: -1
                 });
                 


### PR DESCRIPTION
## Summary
- use the "looking around" row for idle animations to avoid flickering
- start cats on frame 16 and update fallback frames for various states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689028048d4c832383e2bdc77654c133